### PR TITLE
Install awscurl to be able to sign curl requests (e.g. to ElasticSearch protected by AWS auth).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install jq
 
 # Install python libraries needed for the scripts running here.
 RUN pip install --upgrade pip && \
-  pip install awscli docker-compose proselint python-keystoneclient python-swiftclient requests shyaml
+  pip install awscli awscurl docker-compose proselint python-keystoneclient python-swiftclient requests shyaml
 
 ENV GITHUB_HUB_VERSION 2.3.0-pre8
 RUN set -ex; \


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-circleci/13)
<!-- Reviewable:end -->
