### PR TITLE
[Main] Use a name-agnostic way of testing for default branch.

### DIFF
--- a/bin/is_origin_default
+++ b/bin/is_origin_default
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Check that a branch name is the same as origin's default (HEAD).
+
+set -e
+set -o pipefail
+
+readonly BRANCH="${1:-$CIRCLE_BRANCH}"
+readonly REMOTE="${2:-origin}"
+
+[[ "$(git rev-parse --abbrev-ref "$REMOTE/HEAD")" == "$REMOTE/$BRANCH" ]]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-circleci/29)
<!-- Reviewable:end -->
